### PR TITLE
1.0.6

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,4 @@
 recommonmark==0.4.0
 semantic_version==2.6.0
-sphinx_rtd_theme==0.1.9
+sphinx_rtd_theme==0.4.2
 steenzout.sphinx==1.0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-simplejson==3.8.2
+simplejson==3.16.0
 strict_rfc3339==0.7

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,32 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import pip.download
-
-from pip.req import parse_requirements
+import pip
 
 from setuptools import find_packages, setup
 
+if int(pip.__version__.split('.')[0]) >= 10:
+    from pip._internal import download as pip_download
+    from pip._internal.req import parse_requirements
+
+else:
+    from pip import download as pip_download
+    from pip.req import parse_requirements
+
 exec(open('steenzout/serialization/json/metadata.py').read())
+
+
+def requirements(requirements_file):
+    """Return packages mentioned in the given file.
+    Args:
+        requirements_file (str): path to the requirements file to be parsed.
+    Returns:
+        (list): 3rd-party package dependencies contained in the file.
+    """
+    return [
+        str(pkg.req) for pkg in parse_requirements(
+            requirements_file, session=pip_download.PipSession()) if pkg.req is not None]
+
 
 setup(
     name='steenzout.serialization.json',
@@ -21,11 +40,7 @@ setup(
     namespace_packages=['steenzout'],
     packages=find_packages(exclude=('*.tests', '*.tests.*', 'tests.*', 'tests')),
     package_data={'': ['LICENSE', 'NOTICE.md']},
-    install_requires=[
-        str(pkg.req) for pkg in parse_requirements(
-            'requirements.txt', session=pip.download.PipSession())],
-    tests_require=[
-        str(pkg.req) for pkg in parse_requirements(
-            'requirements-test.txt', session=pip.download.PipSession())],
+    install_requires=requirements('requirements.txt'),
+    tests_require=requirements('requirements-test.txt'),
     license=__license__,
     classifiers=__classifiers__)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,5 @@
 [tox]
-envlist =
-    py{36,35,34,33,27}
-    pypy
+envlist = py3{7,6,5},py2{7}
 deps = -rrequirements.txt
 
 
@@ -51,3 +49,4 @@ commands =
 3.4 = py34
 3.5 = py35
 3.6 = py36
+3.7 = py37


### PR DESCRIPTION
- apply [primogen](https://github.com/steenzout/python-primogen) [20181203](https://github.com/steenzout/python-primogen/releases/tag/20181203)
- update dependencies
  - use `sphinx_rtd_theme==0.4.2`
  - use `simplejson==3.16.0`
- map Python 3.7 environment
